### PR TITLE
Fix safe area padding

### DIFF
--- a/src/app/log/page.tsx
+++ b/src/app/log/page.tsx
@@ -109,7 +109,7 @@ export default function MealLogPage() {
       <section className="w-full max-w-sm flex flex-col h-full min-h-0 overflow-hidden relative shadow-xl rounded-3xl bg-white/90 my-2">
         {/* Chat area */}
         <div
-          className="flex-1 flex flex-col overflow-y-auto px-3 pt-5 pb-6 min-h-0"
+          className="flex-1 flex flex-col overflow-y-auto px-3 pt-5 pb-safe-bottom min-h-0"
           onClick={focusInput}
           style={{
             WebkitOverflowScrolling: 'touch',
@@ -216,7 +216,7 @@ export default function MealLogPage() {
           </button>
         </form>
         {chatEnded && (
-          <div className="flex justify-center pb-3">
+          <div className="flex justify-center pb-safe-bottom">
             <button
               onClick={() => router.push('/')}
               className="px-6 py-2 rounded-full bg-gradient-to-r from-pink-400 to-yellow-400 text-white font-semibold text-base shadow-md transition hover:scale-105 mt-3"

--- a/src/app/meals/page.tsx
+++ b/src/app/meals/page.tsx
@@ -635,7 +635,7 @@ export default function MealsPage() {
         </style>
 
         {/* Modal Content */}
-        <div className="flex flex-col flex-1 min-h-0 w-full px-6 pb-3 justify-start">
+        <div className="flex flex-col flex-1 min-h-0 w-full px-6 pb-safe-bottom justify-start">
           {/* Date display */}
           <div className="w-full pt-8 pb-2 flex flex-col items-center">
             <div className="text-center text-gray-600 font-normal uppercase tracking-widest text-[1.15rem] sm:text-[1.25rem] select-none mb-1">

--- a/src/app/notes/page.tsx
+++ b/src/app/notes/page.tsx
@@ -318,7 +318,7 @@ export default function NotesPage() {
       </div>
 
       {/* Main Content */}
-      <main className="max-w-md mx-auto px-4 pb-20">
+      <main className="max-w-md mx-auto px-4 pb-safe-bottom">
         {error ? (
           <motion.div
             initial={{ opacity: 0, y: 20 }}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -579,7 +579,7 @@ function LoadingScreen({ isVisible }: { isVisible: boolean }) {
             initial={{ y: 20, opacity: 0 }}
             animate={{ y: 0, opacity: 1 }}
             transition={{ duration: 1, delay: 0.3, ease: 'easeOut' }}
-            className="relative z-10 text-center px-6 pb-16"
+            className="relative z-10 text-center px-6 pb-safe-bottom"
           >
             <h1
               className="text-lg font-light text-gray-600 mb-3 tracking-wide"
@@ -1315,7 +1315,7 @@ export default function Home() {
           animate={{ opacity: 1 }}
           className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm flex items-center justify-center"
         >
-          <div className="bg-white/90 backdrop-blur-md rounded-2xl p-8 shadow-2xl max-w-sm mx-4">
+          <div className="bg-white/90 backdrop-blur-md rounded-2xl shadow-2xl max-w-sm mx-4 pt-8 px-8 pb-safe-bottom">
             <div className="text-center">
               <div className="mb-4 text-4xl">🔄</div>
               <h3 className="text-lg font-semibold text-gray-800 mb-2">
@@ -1432,7 +1432,7 @@ export default function Home() {
                     </p>
                   </div>
 
-                  <div className="bg-white/80 backdrop-blur-sm rounded-3xl p-8 shadow-2xl border border-white/40">
+                  <div className="bg-white/80 backdrop-blur-sm rounded-3xl shadow-2xl border border-white/40 pt-8 px-8 pb-safe-bottom">
                     <input
                       className="
                         w-full px-6 py-4 mb-6 rounded-2xl border-none shadow-inner
@@ -1739,7 +1739,7 @@ export default function Home() {
                         animate={{ opacity: 1, x: 0 }}
                         exit={{ opacity: 0, x: -20 }}
                         transition={{ duration: 0.3 }}
-                        className="pb-24"
+                        className="pb-safe-bottom"
                       >
                         <span className="block text-xs font-semibold tracking-widest uppercase text-gray-400 mb-5">
                           Meals Today
@@ -1833,7 +1833,7 @@ export default function Home() {
                         animate={{ opacity: 1, x: 0 }}
                         exit={{ opacity: 0, x: 20 }}
                         transition={{ duration: 0.3 }}
-                        className="pb-24"
+                        className="pb-safe-bottom"
                       >
                         <span className="block text-xs font-semibold tracking-widest uppercase text-gray-400 mb-5">
                           Progress
@@ -1978,7 +1978,7 @@ export default function Home() {
                         animate={{ opacity: 1, x: 0 }}
                         exit={{ opacity: 0, x: 20 }}
                         transition={{ duration: 0.3 }}
-                        className="pb-24"
+                        className="pb-safe-bottom"
                       >
                         <span className="block text-xs font-semibold tracking-widest uppercase text-gray-400 mb-5">
                           Friends & Support

--- a/src/app/summaries/page.tsx
+++ b/src/app/summaries/page.tsx
@@ -629,7 +629,7 @@ export default function SummariesPage() {
               </style>
 
               {/* Modal content */}
-              <div className="flex flex-col flex-1 min-h-0 w-full px-6 pb-3 justify-start">
+              <div className="flex flex-col flex-1 min-h-0 w-full px-6 pb-safe-bottom justify-start">
                 {/* Date display */}
                 <div className="w-full pt-8 pb-2 flex flex-col items-center">
                   <div className="text-center text-gray-600 font-normal uppercase tracking-widest text-[1.15rem] sm:text-[1.25rem] select-none mb-1">

--- a/src/components/MealChat.tsx
+++ b/src/components/MealChat.tsx
@@ -477,7 +477,7 @@ export default function MealChat({
 
       {/* Input Bar */}
       {!chatEnded && (
-        <div className="flex-shrink-0 w-full px-4 pb-6 mb-6 sticky bottom-0">
+        <div className="flex-shrink-0 w-full px-4 pb-safe-bottom mb-6 sticky bottom-0">
           <form className="flex items-center gap-3" onSubmit={handleSubmit}>
             <div className="relative flex-1">
               <input


### PR DESCRIPTION
## Summary
- use pb-safe-bottom across app pages so new safe area styles work
- ensure merging overlay and name prompt use safe bottom padding

## Testing
- `npm run lint`
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_687afb120da4832186b4c5f90bb55518