### PR TITLE
Handle safe area padding

### DIFF
--- a/src/app/friends/page.tsx
+++ b/src/app/friends/page.tsx
@@ -28,10 +28,10 @@ const BANNER_TOTAL_HEIGHT =
 function FriendsHeader({ dancingScriptClass }: { dancingScriptClass: string }) {
   return (
     <header
-      className="fixed top-0 left-0 w-full z-30"
+      className="safe-area-pt fixed top-0 left-0 w-full z-30"
       style={{
-        height: BANNER_TOTAL_HEIGHT,
-        minHeight: BANNER_TOTAL_HEIGHT,
+        height: `calc(${BANNER_TOTAL_HEIGHT}px + env(safe-area-inset-top))`,
+        minHeight: `calc(${BANNER_TOTAL_HEIGHT}px + env(safe-area-inset-top))`,
         pointerEvents: 'none',
         background: 'transparent',
         border: 'none',
@@ -316,8 +316,8 @@ export default function FriendsPage() {
       <div
         className="flex-1 w-full max-w-2xl mx-auto flex flex-col relative z-10"
         style={{
-          marginTop: `${BANNER_TOTAL_HEIGHT - 70}px`,
-          height: `calc(100vh - ${BANNER_TOTAL_HEIGHT - 70}px)`,
+          marginTop: `calc(${BANNER_TOTAL_HEIGHT - 70}px + env(safe-area-inset-top))`,
+          height: `calc(100vh - (${BANNER_TOTAL_HEIGHT - 70}px + env(safe-area-inset-top)))`,
           overflow: 'hidden',
         }}
       >

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -116,3 +116,12 @@ a {
     background-color 0.2s,
     color 0.2s;
 }
+
+/* Utility classes for safe area insets */
+.safe-area-pt {
+  padding-top: env(safe-area-inset-top);
+}
+
+.safe-area-pb {
+  padding-bottom: env(safe-area-inset-bottom);
+}

--- a/src/app/meals/page.tsx
+++ b/src/app/meals/page.tsx
@@ -77,10 +77,10 @@ function prettifyText(str: string | null) {
 function MealsHeader({ dancingScriptClass }: { dancingScriptClass: string }) {
   return (
     <header
-      className="fixed top-0 left-0 w-full z-30"
+      className="safe-area-pt fixed top-0 left-0 w-full z-30"
       style={{
-        height: BANNER_TOTAL_HEIGHT,
-        minHeight: BANNER_TOTAL_HEIGHT,
+        height: `calc(${BANNER_TOTAL_HEIGHT}px + env(safe-area-inset-top))`,
+        minHeight: `calc(${BANNER_TOTAL_HEIGHT}px + env(safe-area-inset-top))`,
         pointerEvents: 'none',
         background: 'transparent',
         border: 'none',
@@ -548,8 +548,8 @@ export default function MealsPage() {
       <div
         className="flex-1 w-full max-w-2xl mx-auto flex flex-col relative z-10"
         style={{
-          marginTop: `${BANNER_TOTAL_HEIGHT - 70}px`,
-          height: `calc(100vh - ${BANNER_TOTAL_HEIGHT - 70}px)`,
+          marginTop: `calc(${BANNER_TOTAL_HEIGHT - 70}px + env(safe-area-inset-top))`,
+          height: `calc(100vh - (${BANNER_TOTAL_HEIGHT - 70}px + env(safe-area-inset-top)))`,
           overflow: 'hidden',
         }}
       >

--- a/src/app/notes/page.tsx
+++ b/src/app/notes/page.tsx
@@ -262,7 +262,7 @@ export default function NotesPage() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-pink-50 via-purple-50 to-indigo-50">
       {/* Header */}
-      <header className="bg-white/80 backdrop-blur-sm border-b border-gray-200 sticky top-0 z-40">
+      <header className="safe-area-pt bg-white/80 backdrop-blur-sm border-b border-gray-200 sticky top-0 z-40">
         <div className="max-w-md mx-auto px-4 py-4">
           <div className="flex items-center space-x-4">
             <button

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2098,7 +2098,7 @@ export default function Home() {
                 {/* ============================================================ */}
                 {/* BOTTOM NAVIGATION TABS */}
                 {/* ============================================================ */}
-                <div className="fixed bottom-0 left-0 right-0 bg-white/95 backdrop-blur-md border-t border-gray-100 px-4 py-2 safe-area-pb">
+                <div className="fixed bottom-0 left-0 right-0 bg-white/95 backdrop-blur-md border-t border-gray-100 px-4 py-2 pb-[env(safe-area-inset-bottom)]">
                   <div className="w-full max-w-lg mx-auto">
                     <div className="flex items-center justify-around">
                       {/* Meals tab */}

--- a/src/app/streaks/page.tsx
+++ b/src/app/streaks/page.tsx
@@ -250,10 +250,10 @@ const BANNER_TOTAL_HEIGHT =
 function StreaksHeader({ dancingScriptClass }: { dancingScriptClass: string }) {
   return (
     <header
-      className="fixed top-0 left-0 w-full z-30"
+      className="safe-area-pt fixed top-0 left-0 w-full z-30"
       style={{
-        height: BANNER_TOTAL_HEIGHT,
-        minHeight: BANNER_TOTAL_HEIGHT,
+        height: `calc(${BANNER_TOTAL_HEIGHT}px + env(safe-area-inset-top))`,
+        minHeight: `calc(${BANNER_TOTAL_HEIGHT}px + env(safe-area-inset-top))`,
         pointerEvents: 'none',
         background: 'transparent',
         border: 'none',
@@ -439,11 +439,11 @@ export default function StreaksPage() {
         {/* Main Content Area */}
         <div
           className="flex-1 w-full max-w-2xl mx-auto flex flex-col relative z-10"
-          style={{
-            marginTop: `${BANNER_TOTAL_HEIGHT - 20}px`,
-            height: `calc(100vh - ${BANNER_TOTAL_HEIGHT - 20}px)`,
-            overflow: 'auto',
-          }}
+        style={{
+          marginTop: `calc(${BANNER_TOTAL_HEIGHT - 20}px + env(safe-area-inset-top))`,
+          height: `calc(100vh - (${BANNER_TOTAL_HEIGHT - 20}px + env(safe-area-inset-top)))`,
+          overflow: 'auto',
+        }}
         >
           <div className="px-4 pb-8 pt-8">
             {loading ? (


### PR DESCRIPTION
## Summary
- add new `.safe-area-pt` and `.safe-area-pb` utilities in global CSS
- use environment padding on the homepage bottom nav
- respect the top safe‑area inset on Friends, Meals, Streaks and Notes pages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b0e972c408321af02d317c25a00a7