### PR TITLE
feat: prevent modal conflicts between UpdateNotification and MobileInstallPrompt

### DIFF
--- a/public/versions/update.md
+++ b/public/versions/update.md
@@ -1,12 +1,14 @@
-# Enhanced Meal Tracking Experience
+# Sweethearty Update – Fresh Look, Smarter Notifications & Smoother Navigation
 
-> Experience smoother meal logging with our latest improvements and AI enhancements.
+> Your favourite meal‑tracker just got a major makeover! We’ve overhauled the interface, improved loading times and added a brand‑new update system to keep you in the loop without interrupting your flow.
 
 ## Features
 
-- Improved AI response accuracy and personalization
-- Faster loading times and better performance optimization  
-- Enhanced streak tracking with milestone celebrations
-- Better offline support and data synchronization
-- Refined user interface with accessibility improvements
-- New meal suggestion algorithms based on your preferences
+- Smart update notifications: A new in‑app notification shows release notes from a markdown file. It’s scrollable, beautifully styled and won’t unexpectedly reload your app.
+- Unified celebration & completion modals: Whether you finish logging a meal or complete a chat, you’ll see a consistent glass‑morphism modal with smooth animations and clear calls‑to‑action.
+- MealChat glow‑up: Enjoy a sleek new chat interface with dynamic tab titles, pretty gradient message bubbles and an adorable animated heart icon
+- Faster, smoother navigation: Loading screens now appear across all pages with vibrant gradients and skeletons; page transitions feel native on iOS and the keyboard stays put
+- Modern login & welcome screens: Sign‑in and welcome pages now sport a full‑screen design with bold colours, streamlined buttons and no more unnecessary loading screens
+- Easier PWA installation: A revamped install prompt with platform icons makes adding Sweethearty to your home screen simple
+- Offline‑friendly & mock GPT support: Data is preserved during updates, and developers get a built‑in mock GPT environment for offline testing
+- Rebranded & polished: The app is now called Sweethearty

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,4 @@
 // src/app/layout.tsx - Updated with Mobile Install Prompt
-import DebugControls from '@/components/DebugControls';
 import MobileInstallPrompt from '@/components/MobileInstallPrompt';
 import { NotificationNavigationHandler } from '@/components/NotificationNavigationHandler';
 import UpdateNotification from '@/components/UpdateNotification';
@@ -281,7 +280,7 @@ export default function RootLayout({
         </NavigationProvider>
         <UpdateNotification />
         <Analytics />
-        <DebugControls />
+        {/* <DebugControls /> Enable this when to control update notifications card */}
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -277,7 +277,6 @@ export default function RootLayout({
         <NavigationProvider>
           <NotificationNavigationHandler />
           {children}
-          {/* Mobile Install Prompt - Only shows on mobile touch devices */}
           <MobileInstallPrompt />
         </NavigationProvider>
         <UpdateNotification />

--- a/src/components/MobileInstallPrompt.tsx
+++ b/src/components/MobileInstallPrompt.tsx
@@ -107,6 +107,7 @@ export default function MobileInstallPrompt({
     if (shouldShowPrompt()) {
       const timer = setTimeout(() => {
         setShowPrompt(true);
+        sessionStorage.setItem('mobile_install_showing', 'true');
       }, 1000); // Show after 1 second
 
       return () => clearTimeout(timer);
@@ -115,6 +116,7 @@ export default function MobileInstallPrompt({
 
   const handleDismiss = () => {
     setShowPrompt(false);
+    sessionStorage.removeItem('mobile_install_showing');
     onDismiss?.();
   };
 
@@ -124,6 +126,7 @@ export default function MobileInstallPrompt({
       const success = await PWAInstaller.promptInstall();
       if (success) {
         setShowPrompt(false);
+        sessionStorage.removeItem('mobile_install_showing');
         return;
       }
     }
@@ -179,7 +182,7 @@ export default function MobileInstallPrompt({
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
-            className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50"
+            className="fixed inset-0 bg-black/60 backdrop-blur-sm z-5000"
             onClick={handleDismiss}
             style={{ touchAction: 'none' }}
           />

--- a/src/components/MobileInstallPrompt.tsx
+++ b/src/components/MobileInstallPrompt.tsx
@@ -108,7 +108,7 @@ export default function MobileInstallPrompt({
       const timer = setTimeout(() => {
         setShowPrompt(true);
         sessionStorage.setItem('mobile_install_showing', 'true');
-      }, 1000); // Show after 1 second
+      }, 10); // Show after 1 second
 
       return () => clearTimeout(timer);
     }

--- a/src/components/UpdateNotification.tsx
+++ b/src/components/UpdateNotification.tsx
@@ -106,9 +106,9 @@ export default function UpdateNotification() {
             // Small delay to ensure smooth transition
             setTimeout(() => {
               setShowNotification(true);
-            }, 500);
+            }, 1000);
           }
-        }, 1000);
+        }, 100);
 
         return () => clearInterval(checkInterval);
       } else {

--- a/src/components/UpdateNotification.tsx
+++ b/src/components/UpdateNotification.tsx
@@ -92,11 +92,32 @@ export default function UpdateNotification() {
 
   useEffect(() => {
     if (isUpdateAvailable && !loadingContent) {
-      // Small delay to ensure app is fully loaded before showing notification
-      const timer = setTimeout(() => {
-        setShowNotification(true);
-      }, 1000);
-      return () => clearTimeout(timer);
+      // Check if MobileInstallPrompt is currently showing
+      const isMobileInstallShowing =
+        sessionStorage.getItem('mobile_install_showing') === 'true';
+
+      if (isMobileInstallShowing) {
+        // Wait for MobileInstallPrompt to be dismissed, then show update notification
+        const checkInterval = setInterval(() => {
+          const stillShowing =
+            sessionStorage.getItem('mobile_install_showing') === 'true';
+          if (!stillShowing) {
+            clearInterval(checkInterval);
+            // Small delay to ensure smooth transition
+            setTimeout(() => {
+              setShowNotification(true);
+            }, 500);
+          }
+        }, 1000);
+
+        return () => clearInterval(checkInterval);
+      } else {
+        // Small delay to ensure app is fully loaded before showing notification
+        const timer = setTimeout(() => {
+          setShowNotification(true);
+        }, 1000);
+        return () => clearTimeout(timer);
+      }
     }
   }, [isUpdateAvailable, loadingContent]);
 


### PR DESCRIPTION
- Add sessionStorage coordination to prevent both modals showing simultaneously
- UpdateNotification now waits for MobileInstallPrompt dismissal before appearing
- Implement smooth 500ms transition delay between modal states
- Maintain user experience by showing install prompt priority over update notifications
- Use lightweight sessionStorage solution for cross-component state management

Fixes: Modal overlap causing poor UX on mobile devices during app installation flow